### PR TITLE
Fix issue in fsfuzzer that it will run in ppc64le

### DIFF
--- a/config.guess
+++ b/config.guess
@@ -937,6 +937,10 @@ EOF
     ppc64:Linux:*:*)
 	echo powerpc64-unknown-linux-gnu
 	exit ;;
+    ppc64le:Linux:*:*)
+        echo powerpc64-unknown-linux-gnu
+        exit ;;
+
     alpha:Linux:*:*)
 	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo` in
 	  EV5)   UNAME_MACHINE=alphaev5 ;;

--- a/fsfuzz
+++ b/fsfuzz
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # (c) 2006-2009 Steve Grubb <sgrubb@redhat.com>
 # (c) 2006, LMH <lmh@info-pull.com>
 #

--- a/fstest.c
+++ b/fstest.c
@@ -42,7 +42,7 @@
 #define CHECK_XATTR 1
 
 #ifdef CHECK_XATTR
-#include <attr/xattr.h>
+#include <sys/xattr.h> //glibc-headers provide this
 #define MAXLISTBUF 65536
 #endif
 


### PR DESCRIPTION
Signed-off-by: praveen@linux.vnet.ibm.com
Fix this issue 
1-fix config.guess that it able to configure in ppc64le machine
2- fix fstest.c that <attr/xattr.h> include not working and glibc-headers provide /usr/include/sys/xattr.h
3- fix fsfuzz shell script that it work on bash environment 
