### PR TITLE
Change btrfs minimum fs size to 136MB

### DIFF
--- a/fsfuzz
+++ b/fsfuzz
@@ -171,7 +171,7 @@ pick_filesystem_size () {
 	;;
 	"btrfs")
 		# for bare mkfs.btrfs; other mkfs options might require more
-		min=16
+		min=136
 	;;
 	"ecryptfs")
 		# ext3 needs at least 1024 journal blocks, say 1024 fs, and


### PR DESCRIPTION
This patch changes minimum file system image size for btrfs
to 136MB

Without this patch 'fsfuzz' errors out the following
"'fs/btrfs.base' is too small to make a usable filesystem
Minimum size for each btrfs device is 142606336."

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>